### PR TITLE
Feature/dblp xml

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "command": "npm run test",
+        "name": "Tests",
+        "request": "launch",
+        "type": "node-terminal"
+      }
+    ]
+  }
+  

--- a/errors.js
+++ b/errors.js
@@ -1,6 +1,6 @@
 class OpenReviewError extends Error {
   constructor({ cause, message, name, status, details, options }) {
-    super(message);
+    super(message, { cause });
     this.name = name || 'Error';
     this.status = status || 400;
 
@@ -9,7 +9,6 @@ class OpenReviewError extends Error {
     }
 
     if (cause) {
-      this.cause = cause;
       this.message = !options?.skipCauseMessage ? `${message}: ${cause.message}` : message;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreview/client",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreview/client",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
+        "fast-xml-parser": "^4.3.2",
         "form-data-encoder": "^1.9.0",
         "formdata-node": "^4.4.1",
         "node-fetch": "^2.7.0",
@@ -1097,6 +1098,27 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2575,6 +2597,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3710,6 +3737,14 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4722,6 +4757,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreview/client",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Node.js client library for OpenReview's academic publishing API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
+    "fast-xml-parser": "^4.3.2",
     "form-data-encoder": "^1.9.0",
     "formdata-node": "^4.4.1",
     "node-fetch": "^2.7.0",

--- a/test/test.js
+++ b/test/test.js
@@ -711,4 +711,96 @@ describe('OpenReview Client', function () {
     assert.equal(conflicts.length, 1);
     assert.equal(conflicts[0], 'facebook.com');
   });
+
+  it('should convert DBLP xml to Note Edit', async function () {
+    const dblpXmls = [
+      '<inproceedings key="conf/acl/KimBL16" mdate="2018-09-12">\n<author>Seokhwan Kim</author>\n<author>Rafael E. Banchs</author>\n<author>Haizhou Li 0001</author>\n<title>Exploring Convolutional and Recurrent Neural Networks in Sequential Labelling for Dialogue Topic Tracking.</title>\n<year>2016</year>\n<booktitle>ACL (1)</booktitle>\n<ee>http://aclweb.org/anthology/P/P16/P16-1091.pdf</ee>\n<crossref>conf/acl/2016-1</crossref>\n<url>db/conf/acl/acl2016-1.html#KimBL16</url>\n</inproceedings>',
+      '<proceedings key="conf/acl/1987" mdate="2017-05-10">\n<editor>Candy L. Sidner</editor>\n<title>25th Annual Meeting of the Association for Computational Linguistics, Stanford University, Stanford, California, USA, July 6-9, 1987.</title>\n<booktitle>ACL</booktitle>\n<publisher>ACL</publisher>\n<year>1987</year>\n<ee>http://aclweb.org/anthology/P/P87/</ee>\n<url>db/conf/acl/acl1987.html</url>\n</proceedings>\n\n',
+      '<inproceedings key="conf/acl/Rajasekaran95" mdate="2016-12-19">\n<author>Sanguthevar Rajasekaran</author>\n<title>TAL Recognition in O(M(n<sup>2</sup>)) Time.</title>\n<pages>166-173</pages>\n<year>1995</year>\n<crossref>conf/acl/1995</crossref>\n<booktitle>ACL</booktitle>\n<url>db/conf/acl/acl95.html#Rajasekaran95</url>\n<ee>http://aclweb.org/anthology/P/P95/P95-1023.pdf</ee>\n</inproceedings>',
+      '<inproceedings key="conf/aaai/TanYWHTS16" mdate="2018-11-20">\n<author>Mingkui Tan</author>\n<author>Yan Yan 0006</author>\n<author>Li Wang 0033</author>\n<author>Anton van den Hengel</author>\n<author>Ivor W. Tsang</author>\n<author>Qinfeng (Javen) Shi</author>\n<title>Learning Sparse Confidence-Weighted Classifier on Very High Dimensional Data.</title>\n<pages>2080-2086</pages>\n<year>2016</year>\n<booktitle>AAAI</booktitle>\n<ee>http://www.aaai.org/ocs/index.php/AAAI/AAAI16/paper/view/12329</ee>\n<crossref>conf/aaai/2016</crossref>\n<url>db/conf/aaai/aaai2016.html#TanYWHTS16</url>\n</inproceedings>',
+    ];
+
+    const resolved = [
+      {
+        cdate: 1451606400000,
+        content: {
+          venue: { value: 'ACL (1) 2016' },
+          venueid: { value: 'dblp.org/conf/ACL/2016' },
+          _bibtex: { value: '@inproceedings{DBLP:conf/acl/KimBL16,\n  author={Seokhwan Kim and Rafael E. Banchs and Haizhou Li},\n  title={Exploring Convolutional and Recurrent Neural Networks in Sequential Labelling for Dialogue Topic Tracking},\n  year={2016},\n  cdate={1451606400000},\n  url={http://aclweb.org/anthology/P/P16/P16-1091.pdf},\n  booktitle={ACL (1)},\n  crossref={conf/acl/2016-1}\n}\n' },
+          authors: { value: [ 'Seokhwan Kim', 'Rafael E. Banchs', 'Haizhou Li' ] },
+          authorids: { value: [
+            'https://dblp.org/search/pid/api?q=author:Seokhwan_Kim:',
+            'https://dblp.org/search/pid/api?q=author:Rafael_E._Banchs:',
+            'https://dblp.org/search/pid/api?q=author:Haizhou_Li_0001:'
+          ] },
+          'pdf': { value: 'http://aclweb.org/anthology/P/P16/P16-1091.pdf' },
+          'title': { value: 'Exploring Convolutional and Recurrent Neural Networks in Sequential Labelling for Dialogue Topic Tracking' }
+        }
+      },
+      {
+        cdate: 536457600000,
+        content: {
+          venue: { value: 'ACL 1987' },
+          venueid: { value: 'dblp.org/conf/ACL/1987' },
+          _bibtex: { value: '@proceedings{DBLP:conf/acl/1987,\n  author={},\n  title={25th Annual Meeting of the Association for Computational Linguistics, Stanford University, Stanford, California, USA, July 6-9, 1987},\n  year={1987},\n  cdate={536457600000},\n  url={http://aclweb.org/anthology/P/P87/},\n  booktitle={ACL},\n  publisher={ACL}\n}\n' },
+          authors: { value: [] },
+          authorids: { value: [] },
+          html: { value: 'http://aclweb.org/anthology/P/P87/' },
+          title: { value: '25th Annual Meeting of the Association for Computational Linguistics, Stanford University, Stanford, California, USA, July 6-9, 1987' }
+        }
+      },
+      {
+        cdate: 788918400000,
+        content: {
+          venue: { value: 'ACL 1995' },
+          venueid: { value: 'dblp.org/conf/ACL/1995' },
+          _bibtex: { value: '@inproceedings{DBLP:conf/acl/Rajasekaran95,\n  author={Sanguthevar Rajasekaran},\n  title={TAL Recognition in O(M(n)) Time},\n  year={1995},\n  cdate={788918400000},\n  pages={166-173},\n  url={http://aclweb.org/anthology/P/P95/P95-1023.pdf},\n  booktitle={ACL},\n  crossref={conf/acl/1995}\n}\n' },
+          authors: { value: [ 'Sanguthevar Rajasekaran' ] },
+          authorids: { value: [ 'https://dblp.org/search/pid/api?q=author:Sanguthevar_Rajasekaran:' ] },
+          pdf: { value: 'http://aclweb.org/anthology/P/P95/P95-1023.pdf' },
+          title: { value: 'TAL Recognition in O(M(n)) Time' }
+        }
+      },
+      {
+        cdate: 1451606400000,
+        content: {
+          venue: { value: 'AAAI 2016' },
+          venueid: { value: 'dblp.org/conf/AAAI/2016' },
+          _bibtex: { value: '@inproceedings{DBLP:conf/aaai/TanYWHTS16,\n  author={Mingkui Tan and Yan Yan and Li Wang and Anton van den Hengel and Ivor W. Tsang and Qinfeng Javen Shi},\n  title={Learning Sparse Confidence-Weighted Classifier on Very High Dimensional Data},\n  year={2016},\n  cdate={1451606400000},\n  pages={2080-2086},\n  url={http://www.aaai.org/ocs/index.php/AAAI/AAAI16/paper/view/12329},\n  booktitle={AAAI},\n  crossref={conf/aaai/2016}\n}\n' },
+          authors: { value: [ 'Mingkui Tan', 'Yan Yan', 'Li Wang', 'Anton van den Hengel', 'Ivor W. Tsang', 'Qinfeng Javen Shi' ] },
+          authorids: { value: [
+            'https://dblp.org/search/pid/api?q=author:Mingkui_Tan:',
+            'https://dblp.org/search/pid/api?q=author:Yan_Yan_0006:',
+            'https://dblp.org/search/pid/api?q=author:Li_Wang_0033:',
+            'https://dblp.org/search/pid/api?q=author:Anton_van_den_Hengel:',
+            'https://dblp.org/search/pid/api?q=author:Ivor_W._Tsang:',
+            'https://dblp.org/search/pid/api?q=author:Qinfeng_(Javen)_Shi:'
+          ]},
+          html: { value: 'http://www.aaai.org/ocs/index.php/AAAI/AAAI16/paper/view/12329' },
+          title: { value: 'Learning Sparse Confidence-Weighted Classifier on Very High Dimensional Data' }
+        }
+      }
+    ];
+
+    for (let i = 0; i < dblpXmls.length; i++) {
+      const note = this.superClient.tools.covertDblpXmlToNote(dblpXmls[i]);
+      const resolvedNote = resolved[i];
+      if (resolvedNote.pdate) {
+        assert.equal(note.pdate, resolvedNote.pdate);
+      }
+      if (resolvedNote.cdate) {
+        assert.equal(note.cdate, resolvedNote.cdate);
+      }
+      for (const [ key, { value } ] of Object.entries(resolvedNote.content)) {
+        if (Array.isArray(value)) {
+          assert.equal(note.content[key].value.length, value.length);
+          for (let i = 0; i < value.length; i++) {
+            assert.equal(note.content[key].value[i], value[i]);
+          }
+        } else {
+          assert.equal(note.content[key].value, value);
+        }
+      }
+    }
+  });
 });

--- a/tools.js
+++ b/tools.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const fs = require('fs').promises;
+const { XMLParser } = require('fast-xml-parser');
 const { isValid, getDomain } = require('tldjs');
 const { OpenReviewError } = require('./errors');
 
@@ -661,6 +662,206 @@ class Tools {
     };
   }
 
+  #variableType(variable) {
+    if (variable === null) return 'null';
+    if (Array.isArray(variable)) {
+      return 'array';
+    }
+    return typeof variable;
+  }
+
+  covertDblpXmlToNote(dblpXml) {
+    const removeDigitsRegEx = /\s\d{4}$/;
+    const removeTrailingPeriod = /\.$/;
+
+    if (!this.xmlParser) {
+      this.xmlParser = new XMLParser({ ignoreAttributes: false });
+    }
+
+    if (!this.entryTypes) {
+      this.entryTypes = [
+        'article',
+        'book',
+        'booklet',
+        'conference',
+        'inbook',
+        'incollection',
+        'inproceedings',
+        'manual',
+        'mastersthesis',
+        'misc',
+        'phdthesis',
+        'proceedings',
+        'techreport',
+        'unpublished'
+      ];
+    }
+
+    const getRawDataValue = rawData => {
+      const rawDataType = this.#variableType(rawData);
+      if (rawDataType === 'object') {
+        return rawData['#text'];
+      } else {
+        return rawData;
+      }
+    };
+
+    const getAuthorData = authorData => {
+      const author = getRawDataValue(authorData);
+      return {
+        author: author.replace(removeDigitsRegEx, '').replaceAll('(', '').replaceAll(')', ''),
+        authorid: `https://dblp.org/search/pid/api?q=author:${author.split(' ').join('_')}:`
+      };
+    };
+
+    const entryToData = entryElement => {
+      const data = {};
+      data.type = this.entryTypes.find(type => entryElement[type]) || 'misc';
+      const rawData = entryElement[data.type];
+      data.key = rawData['@_key'];
+      data.publtype = rawData['@_publtype'];
+      data.authors = [];
+      data.authorids = [];
+      // TODO: Check if we want to include rawData.editor too or keep empty authors
+      if (Array.isArray(rawData.author)) {
+        for (const authorData of rawData.author) {
+          const { author, authorid } = getAuthorData(authorData);
+          data.authors.push(author);
+          data.authorids.push(authorid);
+        }
+      } else if (typeof rawData.author === 'string') {
+        const { author, authorid } = getAuthorData(rawData.author);
+        data.authors.push(author);
+        data.authorids.push(authorid);
+      }
+
+      // TODO: What do we do with titles like: Learning Perceptually-Grounded Semantics in The L<sub>0</sub> Project?
+      // Multiple Kernel <i>k</i>-Means Clustering with Matrix-Induced Regularization.
+      data.title = getRawDataValue(rawData.title)?.trim()?.replace('\n', '')?.replace(removeTrailingPeriod, '');
+      data.year = parseInt(getRawDataValue(rawData.year), 10);
+      data.month = getRawDataValue(rawData.month);
+
+      if (data.year) {
+        const cdateString = data.month ? `${data.month} ${data.year}` : data.year;
+        data.cdate = Date.parse(cdateString);
+      }
+
+      data.journal = getRawDataValue(rawData.journal);
+      data.volume = getRawDataValue(rawData.volume);
+      data.number = getRawDataValue(rawData.number);
+      data.chapter = getRawDataValue(rawData.chapter);
+      data.pages = getRawDataValue(rawData.pages);
+      data.url = Array.isArray(rawData.ee) ? getRawDataValue(rawData.ee[0]) : getRawDataValue(rawData.ee);
+      data.isbn = Array.isArray(rawData.isbn) ? getRawDataValue(rawData.isbn[0]) : getRawDataValue(rawData.isbn); // TODO: Check if we want to concatenate this with ands
+      data.booktitle = getRawDataValue(rawData.booktitle);
+      data.crossref = getRawDataValue(rawData.crossref);
+      data.publisher = getRawDataValue(rawData.publisher);
+      data.school = getRawDataValue(rawData.school);
+
+      for (const key of Object.keys(data)) {
+        if (data[key] === undefined || data[key] === null) {
+          delete data[key];
+        }
+      }
+      return data;
+    };
+
+    const dataToBibtex = data => {
+      const bibtexIndent = '  ';
+      const bibtexComponents = [ '@', data.type, '{', 'DBLP:', data.key, ',\n' ];
+
+      const omittedFields = ['type', 'key', 'authorids'];
+
+      for (let [ field, value ] of Object.entries(data)) {
+        if (!value || omittedFields.includes(field)) {
+          continue;
+        }
+
+        let valueString;
+        if (Array.isArray(value)) {
+          valueString = value.join(' and ');
+          if (field.endsWith('s')) {
+            field = field.substring(0, field.length - 1);
+          }
+        } else {
+          valueString = String(value);
+        }
+
+        bibtexComponents.push(...[ bibtexIndent, field, '={', valueString, '},\n' ]);
+      }
+
+      bibtexComponents[bibtexComponents.length - 1] = bibtexComponents[bibtexComponents.length - 1].replace(',\n', '\n');
+      bibtexComponents.push('}\n');
+      return bibtexComponents.join('');
+    };
+
+    let dblpJson;
+    try {
+      dblpJson = this.xmlParser.parse(dblpXml);
+    } catch (err) {
+      throw new OpenReviewError({
+        message: 'Something went wrong parsing the dblp xml',
+        cause: err
+      });
+    }
+
+    if (Object.keys(dblpJson).length === 0) {
+      throw new OpenReviewError({
+        message: 'Something went wrong parsing the dblp xml'
+      });
+    }
+
+    const data = entryToData(dblpJson);
+
+    const note = {
+      cdate: data.cdate,
+      pdate: new Date(data.year, 0, 1).getTime(),
+      content: {
+        title: { value: data.title },
+        _bibtex: { value: dataToBibtex(data) },
+        authors: { value: data.authors },
+        authorids: { value: data.authorids }
+      }
+    };
+
+    const venue = data.journal || data.booktitle;
+    if (venue) {
+      note.content.venue = { value: venue };
+    }
+
+    if (data.key) {
+      const keyParts = data.key.split('/');
+      const venueidParts = [ 'dblp.org' ];
+      // get all but the last part of the key\n
+      for (let i = 0; i < keyParts.length - 1; i++) {
+        let keyPart = keyParts[i];
+        if (i === keyParts.length - 2) {
+          keyPart = keyPart.toUpperCase();
+        }
+        venueidParts.push(keyPart);
+      }
+
+      // we might not want this later
+      if (data.year) {
+        venueidParts.push(data.year);
+        // new addition at Andrew's request
+        if (venue) {
+          note.content.venue.value += ` ${data.year}`;
+        }
+      }
+      note.content.venueid = { value: venueidParts.join('/') };
+    }
+
+    if (data.url) {
+      if (data.url.endsWith('.pdf')) {
+        note.content.pdf = { value: data.url };
+      } else {
+        note.content.html = { value: data.url };
+      }
+    }
+
+    return note;
+  }
 }
 
 module.exports = Tools;


### PR DESCRIPTION
This PR adds the feature of converting dblp xmls to notes. The implementation was based on the [previous transform function](https://github.com/openreview/openreview-py/blob/master/openreview/profile/process/dblp_transform.js).

Instead of using [elemtree](https://www.npmjs.com/package/elementtree) to parse the XML, I used [fast-xml-parser](https://www.npmjs.com/package/fast-xml-parser) which is still maintained.

The implementation was tested against 10,000 Notes that are currently in the live site to make sure that the results were consistent. While doing this, I noted that there are some bugs in the original code. Those were fixed in this version.

There are some things that may need to be discussed that are currently written in the code as TODOs:
- Some dblp xmls have editors instead of authors. The current implementation leaves the authors list empty. Example: https://api.openreview.net/references?referent=HkQ4ie_bB
- Some titles have tags like `<i>` and `<sub>`. The original code trims the title when it encounters the tag. The new code trims the characters inside the tags and continues appending the rest of the text. Example: https://api.openreview.net/references?referent=ryjK6euZH
- Some dblp records have more than one isbn that is included in the bibtex. Should we concatenate the isbns with ` and ` or simply use the first one like the original code? Right now, the behavior is the same as the original code.