### PR TITLE
Feature/use after param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3652,7 +3652,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -3660,7 +3662,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5067,6 +5067,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
@@ -9119,14 +9124,15 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "license": "MIT",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -602,7 +602,10 @@ export default class OpenReviewClient {
    * @returns {Promise<{groups: Array<Object>, count: number}>} - Object containing an array of Groups and the count of all Groups.
    */
   async getAllGroups(params) {
-    return this.tools.getAll(this.getGroups.bind(this), params);
+    delete params.limit;
+    delete params.offset;
+    params.stream = true;
+    return this.getGroups(params);
   }
 
   /**

--- a/packages/client/src/tools.js
+++ b/packages/client/src/tools.js
@@ -260,7 +260,7 @@ export default class Tools {
    * @returns {Promise<object>} - The results of the function call.
    */
   async getAll(func, params) {
-    params.offset = 0;
+    delete params.offset;
 
     if (params.limit && (params.limit <= this.client.RESPONSE_SIZE)) {
       return func(params);
@@ -277,16 +277,24 @@ export default class Tools {
       }
     }
 
+    if (!params.sort) {
+      params.sort = 'id:asc';
+    }
+    params.limit = this.client.RESPONSE_SIZE;
+
     async function* gen() {
       let index = 0;
       let res = await func(params);
+      // Get the last ID of the first batch
+      params.after = res[docType]?.[res[docType].length - 1]?.id;
       while (index < count) {
         if (res[docType].length > 0) {
           yield res[docType].shift();
           index++;
         } else {
-          params.offset += this.client.RESPONSE_SIZE;
           res = await func(params);
+          // Get the last ID of the current batch
+          params.after = res[docType]?.[res[docType].length - 1]?.id;
         }
       }
     }

--- a/packages/client/test/test.js
+++ b/packages/client/test/test.js
@@ -250,8 +250,8 @@ describe('OpenReview Client', function () {
           readers: [ 'everyone' ],
           signatures: { param: { regex: '.+' } },
           writers: { param: { regex: '.*' } },
-          head: { param: { type: 'profile' } },
-          tail: { param: { type: 'profile' } },
+          head: { param: { type: 'group' } },
+          tail: { param: { type: 'group' } },
           label: { param: { regex: '.*' } },
           weight: { param: { minimum: 0 } }
         }


### PR DESCRIPTION
This PR:

- Uses `after` param when getting all documents except for groups.
- Uses `stream` param when all groups