### PR TITLE
Tools: remove the message call when getting an error extracting the abstract

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreview/client",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Node.js client library for OpenReview's academic publishing API",
   "main": "src/index.js",
   "type": "module",

--- a/packages/client/src/tools.js
+++ b/packages/client/src/tools.js
@@ -894,7 +894,7 @@ export default class Tools {
     const contentType = result.headers.get('content-type');
     throw new OpenReviewError({
       name: 'ExtractAbstractError',
-      message: (contentType && contentType.indexOf('application/json') !== -1) ? await result.json().message : await result.text(),
+      message: (contentType && contentType.indexOf('application/json') !== -1) ? await result.json() : await result.text(),
       status: result.status || 500
     });
 


### PR DESCRIPTION
the property `message` doesn't seem to be present when the extractor can not load the url