### PR TITLE
Add profile completion check in tools

### DIFF
--- a/packages/client/src/tools.js
+++ b/packages/client/src/tools.js
@@ -565,7 +565,7 @@ export default class Tools {
    * - 'history': profile must have at least 1 history entry
    * - 'relations': profile must have at least 1 relations entry
    * - 'expertise': profile must have at least 1 expertise entry
-   * - 'publications': profile must have at least 1 public paper
+   * - 'publications': profile must have at least 1 publication
    * - 'active': profile must be active
    *
    * @param {object} profile - Profile to check against requirements.
@@ -575,12 +575,8 @@ export default class Tools {
   checkProfileMinimumRequirements(profile, minRequirements) {
     for (const [field, required] of Object.entries(minRequirements)) {
       if (!required) continue;
-
-      if (field === 'publications') {
-        const publications = profile.content?.publications ?? [];
-        const hasPublic = publications.some(pub => pub.readers?.includes('everyone'));
-        if (!hasPublic) return false;
-      } else if (field === 'relations' || field === 'expertise' || field === 'history') {
+    
+      if (field === 'relations' || field === 'expertise' || field === 'history' || field === 'publications') {
         if (!profile.content?.[field]?.length) return false;
       } else if (field === 'active') {
         if (!profile.state?.toLowerCase().includes('active')) return false;

--- a/packages/client/test/test.js
+++ b/packages/client/test/test.js
@@ -1983,18 +1983,6 @@ describe('OpenReview Client', function () {
     // publications: has at least one public entry → true
     assert.equal(tools.checkProfileMinimumRequirements(profile, { publications: true }), true);
 
-    // publications: none are public → false
-    const profilePrivatePubs = {
-      id: '~User2',
-      content: { 
-        expertise: [{ keywords: ['machine learning'] }],
-        publications: [
-          { id: 'note1', readers: ['ICLR.cc/2023/Conference'] }
-        ] 
-      }
-    };
-    assert.equal(tools.checkProfileMinimumRequirements(profilePrivatePubs, { publications: true }), false);
-
     // publications: empty array → false
     const profileNoPubs = { id: '~User2', content: { publications: [] } };
     assert.equal(tools.checkProfileMinimumRequirements(profileNoPubs, { publications: true }), false);
@@ -2015,8 +2003,18 @@ describe('OpenReview Client', function () {
     );
 
     // Multiple requirements: one fails → false
+    const profileMissingOnlyPubs = {
+      id: '~User2',
+      state: 'Active',
+      content: {
+        history: [{ position: 'PhD Student', institution: { name: 'MIT' } }],
+        relations: [{ name: 'Jane Doe', relation: 'Advisor' }],
+        expertise: [{ keywords: ['nlp'] }],
+        publications: []
+      }
+    };
     assert.equal(
-      tools.checkProfileMinimumRequirements(profilePrivatePubs, { relations: false, expertise: true, publications: true }),
+      tools.checkProfileMinimumRequirements(profileMissingOnlyPubs, { history: true, relations: true, expertise: true, publications: true, active: true }),
       false
     );
 


### PR DESCRIPTION
- Relates to: https://github.com/openreview/openreview-py/pull/2572

This PR adds a tools function to check a profile against a venue's minimum profile requirements. This is used in the Invite Assignment preprocess.

Changes need to match the openreview-py PR, so before merging this we should make sure there's not more feedback on that PR that needs to be moved here.

Example of what `minRequirements` can look like:
```
{ 
  history: true, 
  relations: false, 
  expertise: true, 
  publications: true, 
  active: true 
}
```